### PR TITLE
feat: make fingerprint unique for different pids on same host

### DIFF
--- a/lib/scuid.js
+++ b/lib/scuid.js
@@ -9,7 +9,7 @@ var os = require( 'os' )
  */
 function pad( str, chr, n ) {
   while( str.length < n ) str = chr + str;
-  return str.substring( 0, n )
+  return str.substring( str.length - n, str.length )
 }
 
 /**

--- a/test/index.js
+++ b/test/index.js
@@ -38,6 +38,33 @@ test( 'scuid', function( assert ) {
 
 })
 
+test( 'createFingerprint', function (assert) {
+
+  assert.equal( typeof scuid.createFingerprint, 'function', 'is a function' )
+
+  var fingerprint = scuid.createFingerprint()
+  assert.equal( typeof fingerprint, 'string', 'returns a string (with no args)' )
+  assert.equal( fingerprint.length, 4, 'fingerprint should be 4 chars long (with no args)' )
+
+  fingerprint = scuid.createFingerprint(2)
+  assert.equal( typeof fingerprint, 'string', 'returns a string (with pid arg)' )
+  assert.equal( fingerprint.length, 4, 'fingerprint should be 4 chars long (with pid arg)' )
+
+  fingerprint = scuid.createFingerprint(2, 'hi')
+  assert.equal( typeof fingerprint, 'string', 'returns a string (with pid and hostname args)' )
+  assert.equal( fingerprint.length, 4, 'fingerprint should be 4 chars long (with pid and hostname args)' )
+
+  // mimic fingerprint of 4 processes with consecutive pids on same host
+  // note that the pids should be larger than 1296 (36 * 36)
+  var hostname = 'somerandomhostname'
+  for( var pid = 28631; pid < 28634; pid++ ) {
+    assert.notEqual( scuid.createFingerprint(pid, hostname), scuid.createFingerprint(pid + 1, hostname), 'fingerprint for consecutive pids on same host should be different: ' + pid + ' and ' + (pid + 1) )
+  }
+
+  assert.end()
+
+})
+
 test( 'collision resistance', function( assert ) {
 
   assert.ok( collide( scuid, 2000000 ), 'IDs should not collide' )


### PR DESCRIPTION
While I like the speed and simplicity of this library, it has a slight problem when it comes to generating unique fingerprints for different processes running on the same host (at least when the pids are greater than 1296) because while [scuid uses the _first_ two chars](https://github.com/jhermsmeier/node-scuid/blob/e32df30baa861e8c97c314ebdba8065f84025f46/lib/scuid.js#L12) from the pid and hostname encoding, [node-fingerprint (used by cuid) uses the _last_ two chars](https://github.com/therealklanni/node-fingerprint/blob/de8c79c50d9b54c68de1154d983d88a69a5bc0a6/index.js#L6).

Not sure if this is intended, but I would prefer the fingerprints to be unique when running multiple instances of the same Node service on a host in a sidecar-style deployment model, as an additional guarantee of uniqueness.

The problem is demonstrated by a new test, which should fail with the first commit and be fixed in a subsequent commit.

Let me know what you think. This change should help improve collision avoidance without hurting performance (benchmark results are similar).